### PR TITLE
Feature/issue 5

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -12,16 +12,20 @@ $(function() {
         $(".pagination").css({
           "visibility" : "visible"
         });
+        $(".pagination a").css({
+          "opacity": "1",
+        });
       }else{
         $(".pagination .active").removeClass("active");
-      }
+        $(".pagination a").css({
+          "opacity": "0",
+          "transition":"opacity 0.5s ease 0.5s"
+        });
+            }
     },
     after:function(i,panels) {
       if(i == 0){
         $(".pagination .active").removeClass("active");
-        $(".pagination").css({
-          "visibility" : "hidden"
-        });
       }
       var pagination = "<ul class=\"pagination\">";
       var activeClass = "";
@@ -96,14 +100,6 @@ function topPageLink(horizontal,vertical){
       "width": "100%"
     });
   }
-}
-
-// pagination非表示
-function hiddenPagination(){
-  $(".pagination .active").removeClass("active");
-  $(".pagination").css({
-    "visibility" : "hidden"
-  });
 }
 
 function OnLinkClick(strLink) {

--- a/js/main.js
+++ b/js/main.js
@@ -18,10 +18,16 @@ $(function() {
           "visibility" : "visible"
         });
       }else{
-        hiddenPagination();
+        $(".pagination .active").removeClass("active");
       }
     },
-    after:function() {
+    after:function(i,panels) {
+      if(i == 0){
+        $(".pagination .active").removeClass("active");
+        $(".pagination").css({
+          "visibility" : "hidden"
+        });
+      }
       var pagination = "<ul class=\"pagination\">";
       var activeClass = "";
       $(".panel").each(function(i) {

--- a/js/main.js
+++ b/js/main.js
@@ -24,9 +24,6 @@ $(function() {
             }
     },
     after:function(i,panels) {
-      if(i == 0){
-        $(".pagination .active").removeClass("active");
-      }
       var pagination = "<ul class=\"pagination\">";
       var activeClass = "";
       $(".panel").each(function(i) {

--- a/js/main.js
+++ b/js/main.js
@@ -1,10 +1,5 @@
 $(function() {
 
-  $(document).ready(function() {
-    // pagination非表示
-    hiddenPagination();
-  });
-
   $.scrollify({
     section:".panel",
     updateHash: true,
@@ -40,7 +35,15 @@ $(function() {
       pagination += "</ul>";
       $(".home").append(pagination);
       $(".pagination a").on("click",$.scrollify.move);
-    }
+    },
+     afterRender:function() {
+       //スクロールバーの高さが一番上だった場合
+       if(document.documentElement.scrollTop == 0){
+         $(".pagination").css({
+           "visibility" : "hidden"
+         });
+       }
+     }
   });
 });
 


### PR DESCRIPTION
## 概要
#5 に対する修正

## 変更内容
1. ページが読み込まれたらpaginationを非表示にするのではなく、 scrollifyのafterRenderが呼ばれたタイミングでスクロールが一番上(#top の場合)に非表示に修正
1. scrollifyのbeforeが呼ばれたタイミングで#topに遷移する場合、0.5秒後にpaginationの透明度を0にする
1. scrollifyのbeforeが呼ばれたタイミングで#top 以外に遷移する場合、paginationの透明度を1にする
1. それに伴い、以前使用していた"visibility" : "hidden"を削除